### PR TITLE
fix: allow error-like objects in the types

### DIFF
--- a/lib/get-error-http-status.js
+++ b/lib/get-error-http-status.js
@@ -3,9 +3,13 @@
 const DEFAULT_STATUS_CODE = 500;
 
 /**
+ * @typedef {Error & {[key: string]: any} | {[key: string]: any}} ErrorLike
+ */
+
+/**
  * Get the HTTP status code for an error.
  *
- * @param {Error} error - The error to get the HTTP status code for.
+ * @param {ErrorLike} error - The error to get the HTTP status code for.
  * @returns {number} - Returns the HTTP status code.
  */
 function getErrorHttpStatus(error) {
@@ -23,7 +27,7 @@ function getErrorHttpStatus(error) {
  * Get an HTTP status code from an error property.
  *
  * @private
- * @param {Error} error - The error to check the property of.
+ * @param {ErrorLike} error - The error to check the property of.
  * @param {string} property - The property name to check.
  * @returns {number | null} - Returns the HTTP status code or null if one is not found.
  */


### PR DESCRIPTION
We've always supported working with plain objects, we should extend this to the types to make it easier to work with this library.